### PR TITLE
修复Android7.0问题在某些情况下无法弹出问题

### DIFF
--- a/lib/src/main/java/razerdp/basepopup/PopupWindowProxy.java
+++ b/lib/src/main/java/razerdp/basepopup/PopupWindowProxy.java
@@ -2,6 +2,7 @@ package razerdp.basepopup;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.Gravity;
@@ -82,7 +83,7 @@ public class PopupWindowProxy extends PopupWindow {
         if (isFixAndroidN && anchor != null) {
             int[] a = new int[2];
             anchor.getLocationInWindow(a);
-            Activity activity = (Activity) anchor.getContext();
+            Activity activity = scanForActivity(anchor.getContext());
             super.showAtLocation((activity).getWindow().getDecorView(), Gravity.NO_GRAVITY, 0, a[1] + anchor.getHeight());
         } else {
             if (isOverAndroidN){
@@ -90,6 +91,17 @@ public class PopupWindowProxy extends PopupWindow {
             }
             super.showAsDropDown(anchor, xoff, yoff, gravity);
         }
+    }
+
+    private Activity scanForActivity(Context cont) {
+        if (cont == null)
+            return null;
+        else if (cont instanceof Activity)
+            return (Activity)cont;
+        else if (cont instanceof ContextWrapper)
+            return scanForActivity(((ContextWrapper)cont).getBaseContext());
+
+        return null;
     }
 
     @Override


### PR DESCRIPTION
问题：
java.lang.ClassCastException: android.view.ContextThemeWrapper cannot be cast to android.app.Activity

PopupWindowProxy.class 86行

父布局：android.support.design.widget.CoordinatorLayout

修改如下：
PopupWindowProxy.class 86行修改如下：
`Activity activity = scanForActivity(anchor.getContext());`

```
private Activity scanForActivity(Context cont) {
        if (cont == null)
            return null;
        else if (cont instanceof Activity)
            return (Activity)cont;
        else if (cont instanceof ContextWrapper)
            return scanForActivity(((ContextWrapper)cont).getBaseContext());

        return null;
    }
```